### PR TITLE
Major update with many new features,  RedisJSON & RediSearch support

### DIFF
--- a/Frends.Community.Redis.Tests/Frends.Community.Redis.Tests.cs
+++ b/Frends.Community.Redis.Tests/Frends.Community.Redis.Tests.cs
@@ -1,19 +1,690 @@
-using NUnit.Framework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using NRedisStack.RedisStackCommands;
+using NRedisStack.Search;
+using NRedisStack.Search.Literals.Enums;
+using StackExchange.Redis;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 
 namespace Frends.Community.Redis.Tests
 {
-    [TestFixture]
-    class TestClass
-    {
-        /// <summary>
-        /// You need to run Frends.Community.Redis.SetPaswordsEnv.ps1 before running unit test, or some other way set environment variables e.g. with GitHub Secrets.
-        /// To do meaningful unit tests, implementation needs to switch to use IConnectionMultiplexer interface instead of the concrete class.
-        /// </summary>
-        [Test]
-        public void TestDummy()
+	[TestClass]
+	public class UnitTests
+	{
+		private static List<string> _keyValueCleanUp = [];
+		private static List<string> _setValueCleanUp = [];
+		private static List<string> _jsonValueCleanUp = [];
+		private static List<string> _indexCleanUp = [];
+
+
+		private static readonly Connection _connection = new()
+		{
+			ConnectionString = "", // Add your Redis connection string here, e.g. "localhost:6379,password=yourpassword"
+			Timeout = 5
+		};
+
+		private static ConnectionMultiplexer _connectionMultiplexer;
+
+		private static readonly Options _options = new()
+		{
+			Workers = 4,
+			InputOutputCompletionPorts = 1
+		};
+
+		[TestInitialize]
+		public void StartUp()
+		{
+		}
+
+		[TestCleanup]
+		public void CleanUp()
+		{
+			DeleteTestData();
+		}
+
+		[TestMethod]
+		public void Test_AddKeyValue()
         {
-            Assert.IsTrue(true);
-        }
-    }
+			// Arrange
+			_setValueCleanUp.AddRange(["test:key:1", "test:key:2"]);
+
+			// Act
+			AddInput input = new()
+			{
+				InputObjectType = ObjectType.KeyValuePair,
+				KeyValuePairInput =
+				[
+					new() {
+						Key = "test:key:1",
+						Value = "TestValue1",
+						TimeToLive = TimeSpan.FromMinutes(5)
+					},
+					new() {
+						Key = "test:key:2",
+						Value = "TestValue2",
+						TimeToLive = TimeSpan.FromMinutes(5)
+					}
+				]
+			};
+
+			List<Result> results = Redis.Add(input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.AreEqual(2, results.Count);
+		}
+
+		[TestMethod]
+		public void Test_AddSetValue()
+		{
+			// Arrange
+			_setValueCleanUp.AddRange(["test:key:3", "test:key:4"]);
+
+			// Act
+			AddInput input = new()
+			{
+				InputObjectType = ObjectType.Set,
+				SetInput =
+				[
+					new() {
+						Key = "test:key:3",
+						Value = ["Value1", "Value2"]
+					},
+					new() {
+						Key = "test:key:4",
+						Value = ["Value1", "Value2"]
+					}
+				]
+			};
+
+			List<Result> results = Redis.Add(input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.AreEqual(2, results.Count);
+		}
+
+		[TestMethod]
+		public void Test_AddJson()
+		{
+			// Arrange
+			_jsonValueCleanUp.AddRange(["test:foo:1", "test:foo:2", "test:foo:3", "test:foo:4"]);
+
+			var existingUser = new
+			{
+				name = "Glenn John",
+				email = "paul.john@example.com",
+				age = 42,
+				city = "London",
+				parent = new
+				{
+					name = "Existing Parent"
+				}
+			};
+
+			var db = GetRedisDatabase();
+			db.JSON().Set("test:foo:1", "$", existingUser);
+
+			// Act
+			AddInput input = new()
+			{
+				InputObjectType = ObjectType.Json,
+				JsonInput =
+				[
+					new() {
+						Key = "test:foo:1",
+						Path = "",
+						Value = new
+						{
+							name = "Paul John",
+							email = "paul.john@example.com",
+							age = 42,
+							city = "London"
+						}
+					},
+					new() {
+						Key = "test:foo:2",
+						Value = new
+						{
+							name = "Eden Zamir",
+							email = "eden.zamir@example.com",
+							age = 29,
+							city = "Tel Aviv"
+						},
+					},
+					new() {
+						Key = "test:foo:3",
+						Value = new
+						{
+							name = "Paul Zamir",
+							email = "paul.zamir@example.com",
+							age = 35,
+							city = "Tel Aviv"
+						},
+					},
+					new () {
+						Key = "test:foo:4",
+						Value = "{\n  \"name\": \"Paul John\",\n    \"age\": 42,\n    \"city\": \"London\"\n}",
+					}
+				]
+			};
+
+			List<Result> results = Redis.Add(input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.AreEqual(4, results.Count);
+
+			var u1 = GetJson("test:foo:1");
+			Assert.AreEqual("Paul John", (string)u1.name);
+			Assert.IsNull(u1.parent);
+
+			var u2 = GetJson("test:foo:2");
+			Assert.AreEqual("Eden Zamir", (string)u2.name);
+			
+			var u3 = GetJson("test:foo:3");
+			Assert.AreEqual(35, (int)u3.age);
+			
+			var u4 = GetJson("test:foo:4");
+			Assert.AreEqual("London", (string)u4.city);
+		}
+
+		[TestMethod] 
+		public void Test_GetJson()
+		{
+			// Arrange
+			_jsonValueCleanUp.AddRange(["test:user:0"]);
+
+			var user1 = new
+			{
+				name = "Paul John",
+				email = "paul.john@example.com",
+				age = 42,
+				city = "London"
+			};
+
+			var db = GetRedisDatabase();
+			db.JSON().Set("test:user:0", "$", user1);
+
+			// Act
+			GetInput input = new()
+			{
+				ObjectType = ObjectType.Json,
+				JsonKey = "test:user:0"
+			};
+
+			GetResult result = Redis.Get(input, _connection, _options, CancellationToken.None);
+		
+			// Assert
+			Assert.AreEqual(1, result.Values.Count);
+
+			var user = JsonConvert.DeserializeObject<dynamic>(result.Values[0].ToString());
+			Assert.AreEqual("paul.john@example.com", (string)user.email);
+		}
+
+		[TestMethod]
+		public void Test_QueryJson()
+		{
+			// Arrange
+			_indexCleanUp.Add("idx:test:queryjson");
+			_jsonValueCleanUp.AddRange(["test:user:1", "test:user:2", "test:user:3"]);
+
+			var user1 = new
+			{
+				name = "Paul John",
+				email = "paul.john@example.com",
+				age = 42,
+				city = "London"
+			};
+			var user2 = new
+			{
+				name = "Eden Zamir",
+				email = "eden.zamir@example.com",
+				age = 29,
+				city = "Tel Aviv"
+			};
+			var user3 = new
+			{
+				name = "Paul Zamir",
+				email = "paul.zamir@example.com",
+				age = 35,
+				city = "Tel Aviv"
+			};
+			
+			var db = GetRedisDatabase();
+			db.JSON().Set("test:user:1", "$", user1);
+			db.JSON().Set("test:user:2", "$", user2);
+			db.JSON().Set("test:user:3", "$", user3);
+
+			var schema = new Schema();
+			schema.AddTextField(new FieldName("$.name", "name"));
+			schema.AddNumericField(new FieldName("$.age", "age"));
+
+			db.FT()
+				.Create(
+					"idx:test:queryjson",
+					new FTCreateParams()
+						.On(IndexDataType.JSON)
+						.Prefix("test:user"),
+					schema);
+
+			// Act
+			JsonQueryInput input = new()
+			{
+				IndexName = "idx:test:queryjson",
+				Query = "Paul @age:[30 40]"
+			};
+
+			GetResult result = Redis.Query(input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.AreEqual(1, result.Values.Count);
+
+			var user = JsonConvert.DeserializeObject<dynamic>(result.Values[0].ToString());
+			Assert.AreEqual("paul.zamir@example.com", (string)user.email);
+		}
+
+		[TestMethod]
+		public void Test_QueryJson_By_Tag()
+		{
+			// Arrange
+			_indexCleanUp.Add("idx:test:queryjsonbytag");
+			_jsonValueCleanUp.AddRange(["test:user:1", "test:user:2", "test:user:3"]);
+
+			var user1 = new
+			{
+				objectId = "test:user:1",
+				objectDomain = "data",
+				name = "Paul John",
+				email = "paul.john@example.com",
+				age = 42,
+				city = "London"
+			};
+			var user2 = new
+			{
+				objectId = "test:user:2",
+				name = "Eden Zamir",
+				email = "eden.zamir@example.com",
+				age = 29,
+				city = "Tel Aviv"
+			};
+			var user3 = new
+			{
+				objectId = "test:user:3",
+				name = "Paul Zamir",
+				email = "paul.zamir@example.com",
+				age = 35,
+				city = "Tel Aviv"
+			};
+
+			var db = GetRedisDatabase();
+			db.JSON().Set("test:user:1", "$", user1);
+			db.JSON().Set("test:user:2", "$", user2);
+			db.JSON().Set("test:user:3", "$", user3);
+
+			var schema = new Schema();
+			schema.AddTagField(new FieldName("$.objectId", "objectId"));
+			schema.AddTagField(new FieldName("$.objectDomain", "objectDomain"));
+			schema.AddTextField(new FieldName("$.name", "name"));
+			schema.AddNumericField(new FieldName("$.age", "age"));
+
+			db.FT()
+				.Create(
+					"idx:test:queryjsonbytag",
+					new FTCreateParams()
+						.On(IndexDataType.JSON)
+						.Prefix("test:user"),
+					schema);
+
+			Thread.Sleep(500); // Wait for index to be ready
+							   //Query query = new Query("@objectId:{\"urn:bkid:data:datadistributionexport:test-export-incomingblobtoentryscape-outgoing\"}").Dialect(2);
+							   //Query query = new Query("@objectId:{\"test:user:1\"}"); //.Dialect(2);
+
+			////	query.AddParam("objectId", "test:user:1");
+
+			//SearchResult searchResult = db.FT().Search(
+			//	"idx:test:queryjsonbytag",
+			//	query
+			//);
+
+
+			//var foo = searchResult.Documents;
+			//Assert.AreEqual(1, foo.Count);
+			// Act
+			JsonQueryInput input = new()
+			{
+				IndexName = "idx:test:queryjsonbytag",
+				Query = "@objectDomain:{data}"
+			};
+
+			GetResult result = Redis.Query(input, _connection, _options, CancellationToken.None);
+			Assert.AreEqual(1, result.Values.Count);
+
+			var user = JsonConvert.DeserializeObject<dynamic>(result.Values[0].ToString());
+			Assert.AreEqual("paul.john@example.com", (string)user.email);
+		}
+
+
+		[TestMethod]
+		public void Test_MergeJson()
+		{
+			// Arrange
+			var jsonId1 = $"test:{Guid.NewGuid()}";
+			var jsonId2 = $"test:{Guid.NewGuid()}";
+			var jsonId3 = $"test:{Guid.NewGuid()}";
+			_jsonValueCleanUp.AddRange([jsonId1, jsonId2, jsonId3]);
+
+			var json1 = new
+			{
+				a = "Value A",
+				b = 2,
+				c = new {
+					c1 = "Value C1",
+					c2 = "Value C2"
+				}
+			};
+
+			var json2 = new
+			{
+				a = "Value A",
+				b = 3,
+				d = new
+				{
+					d1 = "Value D1",
+					d2 = "Value D2"
+				}
+			};
+
+			var db = GetRedisDatabase();
+			db.JSON().Set(jsonId1, "$", json1);
+			db.JSON().Set(jsonId2, "$", json2);
+
+			// Act
+			MergeInput addInput = new()
+			{
+				ObjectType = ObjectType.Json,
+				JsonInput = new()
+				{
+					Key = jsonId3,
+					Value = new
+					{
+						a = "Value A",
+						b = 99
+
+					}
+				}
+			};
+
+			MergeInput update1Input = new()
+			{
+				ObjectType = ObjectType.Json,
+				JsonInput = new()
+				{
+					Key = jsonId1,
+					Path = "$",
+					Value = new
+					{
+						c = new
+						{
+							c3 = "Value C3"
+						}
+					}
+				}
+			};
+
+			MergeInput update2Input = new()
+			{
+				ObjectType = ObjectType.Json,
+				JsonInput = new()
+				{
+					Key = jsonId2,
+					Path = "$.d",
+					Value = new
+					{
+						d1 = (string)null,
+						d2 = (string)null,
+						d3 = "Value D3"
+					}
+				}
+			};
+
+			Result addResult = Redis.Merge(addInput, _connection, _options, CancellationToken.None);
+			Result update1Result = Redis.Merge(update1Input, _connection, _options, CancellationToken.None);
+			Result update2Result = Redis.Merge(update2Input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.IsTrue(addResult.Success);
+			var o1 = GetJson(jsonId3);
+			Assert.AreEqual("Value A", (string)o1.a);
+			Assert.AreEqual(99, (int)o1.b);
+
+			Assert.IsTrue(update1Result.Success);
+			var o2 = GetJson(jsonId1);
+			Assert.AreEqual("Value A", (string)o2.a);
+			Assert.AreEqual(2, (int)o2.b);
+			Assert.AreEqual("Value C3", (string)o2.c.c3);
+
+			Assert.IsTrue(update2Result.Success);
+			var o3 = GetJson(jsonId2);
+			Assert.AreEqual("Value A", (string)o3.a);
+			Assert.AreEqual(3, (int)o3.b);
+			Assert.IsNull(o3.d.d1);
+			Assert.AreEqual("Value D3", (string)o3.d.d3);
+		}
+
+
+		[TestMethod]
+		public void Test_CreateIndex()
+		{
+			// Arrange
+			_indexCleanUp.Add("idx:test:create");
+
+			// Act
+			IndexCreateInput input = new()
+			{
+				Name = "idx:test:create",
+				Prefix = "user:",
+				Parameters =
+				[
+					new IndexFieldDefinition
+					{
+						Name = "$.name",
+						Attribute = "name",
+						FieldType = FieldDefinitionType.Text
+					},
+					new IndexFieldDefinition
+					{
+						Name = "$.city",
+						Attribute = "city",
+						FieldType = FieldDefinitionType.Text
+					},
+					new IndexFieldDefinition
+					{
+						Name = "$.age",
+						Attribute = "age",
+						FieldType = FieldDefinitionType.Numeric
+					}
+				]
+			};
+
+			Result result = Redis.CreateIndex(input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.IsTrue(result.Success);
+			
+			var db = GetRedisDatabase();
+			var list = db.FT()._List();
+			bool indexExists = list.Any(i => i.ToString() == "idx:test:create");
+			
+			Assert.IsTrue(indexExists);
+		}
+
+		[TestMethod]
+		public void Test_DeleteIndex()
+		{
+			//  Arrange
+			var schema = new Schema();
+			schema.AddTextField(new FieldName("$.name", "name"));
+			schema.AddNumericField(new FieldName("$.age", "age"));
+
+			var db = GetRedisDatabase();
+			var indexCreated = db.FT()
+			.Create(
+				"idx:test:delete",
+				new FTCreateParams()
+					.On(IndexDataType.JSON)
+					.Prefix("idx:test"),
+				schema);
+
+			// Act
+			IndexDeleteInput input = new()
+			{
+				Name = "idx:test:delete",
+				DeleteDocuments = false
+			};
+
+			Result result = Redis.DeleteIndex(input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.IsTrue(result.Success);
+			Thread.Sleep(500);
+
+			var list = db.FT()._List();
+			bool indexExists = list.Any(i => i.ToString() == "idx:test:delete");
+
+			Assert.IsFalse(indexExists);
+		}
+
+		[TestMethod]
+		public void Test_UpdateIndex()
+		{
+			// Arrange
+			_indexCleanUp.Add("idx:test:update");
+			var schema = new Schema();
+			schema.AddTextField(new FieldName("$.name", "name"));
+			schema.AddNumericField(new FieldName("$.age", "age"));
+
+			var db = GetRedisDatabase();
+			 db.FT()
+				.Create(
+					"idx:test:update",
+					new FTCreateParams()
+						.On(IndexDataType.JSON)
+						.Prefix("idx:test"),
+					schema);
+			
+			// Act
+			IndexUpdateInput input = new()
+			{
+				Name = "idx:test:update",
+				Parameters =
+				[
+					new IndexFieldDefinition
+					{
+						Name = "$.foo",
+						Attribute = "foo",
+						FieldType = FieldDefinitionType.Text
+					}
+				]
+			};
+
+			Result result = Redis.UpdateIndex(input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.IsTrue(result.Success);
+
+			var info = db.FT().Info("idx:test:update");
+
+			Assert.IsTrue(info.Attributes.Any(a => a.ContainsKey("identifier") && a["identifier"].ToString() == "$.name"), "$.name is missing");
+			Assert.IsTrue(info.Attributes.Any(a => a.ContainsKey("identifier") && a["identifier"].ToString() == "$.age"), "$.age is missing");
+			Assert.IsTrue(info.Attributes.Any(a => a.ContainsKey("identifier") && a["identifier"].ToString() == "$.foo"), "$.foo is missing");
+		}
+
+		[TestMethod]
+		public void Test_CreateOrUpdateIndex()
+		{
+			// Arrange
+			_indexCleanUp.Add("idx:test:createorupdate");
+
+			// Act
+			IndexCreateOrUpdateInput input = new()
+			{
+				Name = "idx:test:createorupdate",
+				Prefix = "user:",
+				Parameters =
+				[
+					new IndexFieldDefinition
+					{
+						Name = "$.name",
+						Attribute = "name",
+						FieldType = FieldDefinitionType.Text
+					},
+					new IndexFieldDefinition
+					{
+						Name = "$.city",
+						Attribute = "city",
+						FieldType = FieldDefinitionType.Text
+					},
+					new IndexFieldDefinition
+					{
+						Name = "$.age",
+						Attribute = "age",
+						FieldType = FieldDefinitionType.Numeric
+					}
+				]
+			};
+
+			Result result = Redis.CreateOrUpdateIndex(input, _connection, _options, CancellationToken.None);
+
+			// Assert
+			Assert.IsTrue(result.Success);
+		}
+
+		private static dynamic GetJson(string key)
+		{
+			var db = GetRedisDatabase();
+			RedisResult result = db.JSON().Get(key);
+			return JsonConvert.DeserializeObject<dynamic>(result.ToString());
+		}
+
+		private static void DeleteTestData()
+		{
+			var db = GetRedisDatabase();
+
+			foreach (var key in _keyValueCleanUp)
+			{
+				db.KeyDelete(key, CommandFlags.FireAndForget);
+			}
+
+			foreach (var key in _setValueCleanUp)
+			{
+				db.StringDelete(key, When.Always);
+			}
+
+			foreach(var key in _jsonValueCleanUp)
+			{
+				db.JSON().Del(key);
+			}
+
+			foreach (var index in _indexCleanUp)
+			{
+				db.FT().DropIndex(index, false);
+			}
+
+
+			_indexCleanUp.Clear();
+
+
+		}
+
+		private static IDatabase GetRedisDatabase()
+		{
+			if (_connectionMultiplexer == null)
+			{
+				_connectionMultiplexer = RedisConnectionFactory.CreateConnectionWithTimeout(_connection.ConnectionString, new TimeSpan(0, 0, _connection.Timeout));
+			}
+			
+			return _connectionMultiplexer.GetDatabase();
+		}
+	}
 }

--- a/Frends.Community.Redis.Tests/Frends.Community.Redis.Tests.csproj
+++ b/Frends.Community.Redis.Tests/Frends.Community.Redis.Tests.csproj
@@ -1,18 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
-
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="NRedisStack" Version="1.3.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.12.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Frends.Community.Redis/Definition.cs
+++ b/Frends.Community.Redis/Definition.cs
@@ -12,17 +12,31 @@ namespace Frends.Community.Redis
     /// <summary>
     /// Input-object
     /// </summary>
-    public enum ObjectType { KeyValuePair, Set }
+    public enum ObjectType { KeyValuePair, Set, Json }
 
     /// <summary>
     /// When value exists
     /// </summary>
     public enum WhenValueExist { InsertAlways = 0, InsertOnlyIfValueExists = 1, InsertOnlyIfValueDoesNotExist = 2 };
 
-    /// <summary>
-    /// Insert input-object 
-    /// </summary>
-    public class AddInput
+	/// <summary>
+	/// Index field definition type
+	/// </summary>
+	public enum FieldDefinitionType
+	{
+		Text,
+		Geo,
+		GeoShape,
+		Numeric,
+		Tag,
+		Vector
+	}
+
+
+	/// <summary>
+	/// Insert input-object 
+	/// </summary>
+	public class AddInput
     {
         /// <summary>
         /// Type of inserted object
@@ -41,7 +55,13 @@ namespace Frends.Community.Redis
         /// </summary>
         [UIHint(nameof(InputObjectType), "", ObjectType.Set)]
         public SetInput[] SetInput { get; set; }
-    }
+
+		/// <summary>
+		/// Json to insert
+		/// </summary>
+		[UIHint(nameof(InputObjectType), "", ObjectType.Json)]
+		public JsonInput[] JsonInput { get; set; }
+	}
 
     /// <summary>
     /// Get values input
@@ -67,13 +87,82 @@ namespace Frends.Community.Redis
         [DisplayFormat(DataFormatString = "Text")]
         [UIHint(nameof(ObjectType), "", ObjectType.Set)]
         public object SetKey { get; set; }
-    }
 
+		/// <summary>
+		/// Json key
+		/// </summary>
+		[DisplayFormat(DataFormatString = "Text")]
+		[UIHint(nameof(ObjectType), "", ObjectType.Json)]
+		public object JsonKey { get; set; }
+	}
 
-    /// <summary>
-    /// Connection options
-    /// </summary>
-    public class Connection
+	/// <summary>
+	/// Contains input elements for the command task
+	/// </summary>
+	public class CommandInput
+	{
+		/// <summary>
+		/// The command to be executed.
+		/// Ex: idx:users
+		/// </summary>
+		public string Command { get; set; }
+
+		/// <summary>
+		/// Array of parameters for the command.
+		/// Ex: user:
+		/// </summary>
+		public object[] Parameters { get; set; }
+	}
+
+	/// <summary>
+	/// Merge input object for Redis JSON. 
+	/// Contains the JSON to merge and the path where the JSON should be merged. 
+	/// If path is not provided, it will be merged at root ($)
+	/// </summary>
+	public class MergeInput
+	{
+		/// <summary>
+		/// Object type
+		/// </summary>
+		[DefaultValue(ObjectType.KeyValuePair)]
+		public ObjectType ObjectType { get; set; }
+
+		/// <summary>
+		/// Json to merge
+		/// </summary>
+		[UIHint(nameof(ObjectType), "", ObjectType.Json)]
+		public JsonInput JsonInput { get; set; }
+	}
+
+	public class DeleteInput
+	{
+		/// <summary>
+		/// Object type
+		/// </summary>
+		[DefaultValue(ObjectType.KeyValuePair)]
+		public ObjectType ObjectType { get; set; }
+
+		/// <summary>
+		/// Set key and set values to delete
+		/// </summary>
+		[UIHint(nameof(ObjectType), "", ObjectType.Set)]
+		public SetInput SetInput { get; set; }
+
+		/// <summary>
+		/// Keys for Key-Value pairs to delete
+		/// </summary>
+		[UIHint(nameof(ObjectType), "", ObjectType.KeyValuePair)]
+		[DisplayFormat(DataFormatString = "Text")]
+		public object[] Key { get; set; }
+
+		[UIHint(nameof(ObjectType), "", ObjectType.Json)]
+		public JsonInput JsonInput { get; set; }
+	}
+
+	/// <summary>
+	/// Connection options
+	/// </summary>
+	public class Connection
     {
         /// <summary>
         /// Connection string
@@ -112,7 +201,7 @@ namespace Frends.Community.Redis
         /// </summary>
         [DefaultValue(1)]
         public int InputOutputCompletionPorts { get; set; }
-    }
+	}
 
     /// <summary>
     /// Input object for key-value pairs
@@ -174,48 +263,128 @@ namespace Frends.Community.Redis
         public object[] Value { get; set; }
     }
 
-    public class DeleteInput
-    {
-        /// <summary>
-        /// Object type
-        /// </summary>
-        [DefaultValue(ObjectType.KeyValuePair)]
-        public ObjectType ObjectType { get; set; }
+	public class JsonInput
+	{
+		/// <summary>
+		/// Json key
+		/// </summary>
+		[DisplayFormat(DataFormatString = "Text")]
+		public object Key { get; set; }
 
-        /// <summary>
-        /// Set key and set values to delete
-        /// </summary>
-        [UIHint(nameof(ObjectType), "", ObjectType.Set)]
-        public SetInput SetInput { get; set; }
+		/// <summary>
+		/// Json value
+		/// </summary>
+		[DisplayFormat(DataFormatString = "Text")]
+		public object Value { get; set; }
 
-        /// <summary>
-        /// Keys for Key-Value pairs to delete
-        /// </summary>
-        [UIHint(nameof(ObjectType), "", ObjectType.KeyValuePair)]
-        [DisplayFormat(DataFormatString = "Text")]
-        public object[] Key { get; set; }
-    }
+		/// <summary>
+		/// JSONPath to specify. Default is root $. Nonexisting paths are ignored.
+		/// </summary>
+		[DisplayFormat(DataFormatString = "Text")]
+		public object Path { get; set; }
+	}
 
-    /// <summary>
-    /// Contains input elements for the command task
-    /// </summary>
-    public class CommandInput
-    {
-        /// <summary>
-        /// The command to be executed
-        /// </summary>
-        public string Command { get; set; }
+	public class JsonQueryInput
+	{
+		/// <summary>
+		/// Index name for Json query
+		/// </summary>
+		[DisplayFormat(DataFormatString = "Text")]
+		public string IndexName { get; set; }
 
-        /// <summary>
-        /// Array of parameters for the command
-        /// </summary>
-        public object[] Parameters { get; set; }
-    }
+		/// <summary>
+		/// Json query string
+		/// Ex: Paul @age:[30 40]
+		/// </summary>
+		[DisplayFormat(DataFormatString = "Text")]
+		public string Query { get; set; }
+	}
 
-    /// <summary>
-    /// Output-object
-    /// </summary>
-    public class Result
+	public class IndexFieldDefinition
+	{
+		/// <summary>
+		/// Field definition type
+		/// </summary>
+		public FieldDefinitionType FieldType { get; set; }
+
+		/// <summary>
+		/// The identifier is a JSON Path expression
+		/// </summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		/// Alias for th JSONPath expression 
+		/// </summary>
+		public string Attribute { get; set; }
+	}
+
+	public class IndexCreateInput
+	{
+		/// <summary>
+		/// The name of the index.
+		/// </summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		/// The prefix of the keys that should be indexed.
+		/// </summary>
+		public string Prefix { get; set; }
+
+		/// <summary>
+		/// Array of fields for the index.
+		/// </summary>
+		public IndexFieldDefinition[] Parameters { get; set; }
+	}
+
+	public class IndexDeleteInput
+	{
+		/// <summary>
+		/// The name of the index.
+		/// </summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		///  Delete the documents associated with the index.
+		/// </summary>
+		[DefaultValue(false)]
+		public bool DeleteDocuments { get; set; }
+	}
+
+	public class IndexUpdateInput
+	{
+		/// <summary>
+		/// The name of the index.
+		/// </summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		/// Array of fields for the index.
+		/// </summary>
+		public IndexFieldDefinition[] Parameters { get; set; }
+	}
+
+	public class IndexCreateOrUpdateInput
+	{
+		/// <summary>
+		/// The name of the index.
+		/// </summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		/// The prefix of the keys that should be indexed.
+		/// </summary>
+		public string Prefix { get; set; }
+
+		/// <summary>
+		/// Array of fields for the index.
+		/// </summary>
+		public IndexFieldDefinition[] Parameters { get; set; }
+	}
+
+	/// <summary>
+	/// Output-object
+	/// </summary>
+	public class Result
     {
         private readonly Lazy<JToken> _jToken;
 

--- a/Frends.Community.Redis/Frends.Community.Redis.cs
+++ b/Frends.Community.Redis/Frends.Community.Redis.cs
@@ -1,9 +1,16 @@
-﻿using System.ComponentModel;
-using System.Threading;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NRedisStack;
+using NRedisStack.RedisStackCommands;
+using NRedisStack.Search;
+using NRedisStack.Search.Literals.Enums;
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Threading;
+
 
 #pragma warning disable 1591
 
@@ -11,17 +18,17 @@ namespace Frends.Community.Redis
 {
     public static class Redis
     {
-        /// <summary>
-        /// A Frends task for adding and updating key-value pairs or a Sets to Redis.
-        /// Returns a List of Result-objects that have properties Success and Value.
-        /// See: https://github.com/CommunityHiQ/Frends.Community.Redis#Add
-        /// </summary>
-        /// <param name="input">Key-Value pairs or a Set</param>
-        /// <param name="connection">Connection-options</param>
-        /// <param name="options">Additional options for the task</param>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>List [ Object { bool Success, object Value } ]</returns>
-        public static List<Result> Add([PropertyTab] AddInput input, [PropertyTab] Connection connection, [PropertyTab] Options options, CancellationToken cancellationToken)
+		/// <summary>
+		/// A Frends task for adding and updating key-value pairs, Sets or Json to Redis.
+		/// Returns a List of Result-objects that have properties Success and Value.
+		/// See: https://github.com/CommunityHiQ/Frends.Community.Redis#Add
+		/// </summary>
+		/// <param name="input">Key-Value pairs or a Set</param>
+		/// <param name="connection">Connection-options</param>
+		/// <param name="options">Additional options for the task</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns>List [ Object { bool Success, object Value } ]</returns>
+		public static List<Result> Add([PropertyTab] AddInput input, [PropertyTab] Connection connection, [PropertyTab] Options options, CancellationToken cancellationToken)
         {
 
             ConnectionMultiplexer connectionMultiplexer = null;
@@ -39,8 +46,8 @@ namespace Frends.Community.Redis
             }
 
             IDatabase database = connectionMultiplexer.GetDatabase();
-
-            if (input.InputObjectType == ObjectType.Set)
+		
+			if (input.InputObjectType == ObjectType.Set)
             {
                 foreach (var item in input.SetInput)
                 {
@@ -49,8 +56,8 @@ namespace Frends.Community.Redis
                     results.Add(new Result((long)_result > -1, item.Key));
                 }
             }
-            else
-            {
+            else if (input.InputObjectType == ObjectType.KeyValuePair)
+			{
                 foreach (var item in input.KeyValuePairInput)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -58,13 +65,37 @@ namespace Frends.Community.Redis
                     results.Add(new Result((bool)_result, item.Key));
                 }
             }
+			else if (input.InputObjectType == ObjectType.Json)
+			{
+				foreach (var item in input.JsonInput)
+				{
+					cancellationToken.ThrowIfCancellationRequested();
+
+					bool result = false;
+					if (item.Value is string)
+					{
+						var json = JsonConvert.DeserializeObject<dynamic>(item.Value.ToString());
+						result = database.JSON().Set(ObjectToRedisKey(item.Key), string.IsNullOrEmpty(item.Path?.ToString()) ? "$" : item.Path.ToString(), JsonConvert.SerializeObject(json));
+					}
+					else
+					{
+						result = database.JSON().Set(ObjectToRedisKey(item.Key), string.IsNullOrEmpty(item.Path?.ToString()) ? "$" : item.Path.ToString(), item.Value);
+					}
+
+					results.Add(new Result(result, item.Key));
+				}
+			}
+			else
+			{
+				throw new ArgumentException("InputObjectType is of invalid type. Accepted types are KeyValuePair, Set or Json");
+			}
 
             return results;
 
         }
 
         /// <summary>
-        /// A Frends task for getting Key-Values or Sets from Redis.
+        /// A Frends task for getting Key-Values, Sets or Json from Redis.
         /// See: https://github.com/CommunityHiQ/Frends.Community.Redis#Get
         /// </summary>
         /// <param name="input">An array of keys for key-value pairs or a key to a set</param>
@@ -96,12 +127,21 @@ namespace Frends.Community.Redis
             {
                 redisValues = database.StringGet(input.Key.Select(key => ObjectToRedisKey(key)).ToArray());
             }
-            else
-            {
+			else if (input.ObjectType == ObjectType.Set)
+			{
                 redisValues = database.SetMembers(ObjectToRedisKey(input.SetKey));
             }
+			else if (input.ObjectType == ObjectType.Json)
+			{
+				RedisResult result = database.JSON().Get(ObjectToRedisKey(input.JsonKey));
+				redisValues = [(RedisValue)result];
+			}
+			else
+			{
+				throw new ArgumentException("InputObjectType is of invalid type. Accepted types are KeyValuePair, Set or Json");
+			}
 
-            foreach (RedisValue value in redisValues)
+			foreach (RedisValue value in redisValues)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -114,9 +154,8 @@ namespace Frends.Community.Redis
             return new GetResult(results);
         }
 
-
         /// <summary>
-        /// A Frends task for removing Key-Value pairs or Set values from Redis. 
+        /// A Frends task for removing Key-Value pairs, Set or Json values from Redis. 
         /// Returns a Result-object with properties Success and Value. 
         /// Value tells how many cache objects were removed.
         /// See: https://github.com/CommunityHiQ/Frends.Community.Redis#Remove
@@ -148,12 +187,21 @@ namespace Frends.Community.Redis
                 var _result = database.KeyDelete(input.Key.Select(key => ObjectToRedisKey(key)).ToArray());
                 return new Result(_result > -1, _result);
             }
-            else
-            {
+			else if (input.ObjectType == ObjectType.Set)
+			{
                 var _result = database.SetRemove(ObjectToRedisKey(input.SetInput.Key), input.SetInput.Value.Select(value => ObjectToRedisValue(value)).ToArray());
                 return new Result(_result > -1, _result);
             }
-        }
+			else if (input.ObjectType == ObjectType.Json)
+			{
+				var _result = database.JSON().Del(ObjectToRedisKey(input.JsonInput.Key), string.IsNullOrEmpty(input.JsonInput.Path?.ToString()) ? "$" : input.JsonInput.Path.ToString());
+				return new Result(_result > -1, _result);
+			}
+			else
+			{
+				throw new ArgumentException("InputObjectType is of invalid type. Accepted types are KeyValuePair, Set or Json");
+			}
+		}
 
         /// <summary>
         /// A Frends task for executing commands on Redis. Returns a list that has the results.
@@ -199,7 +247,293 @@ namespace Frends.Community.Redis
                     return new List<string>(redisResult.ToDictionary().SelectMany(keyVal => new List<string>() { keyVal.Key.ToString(), keyVal.Value.ToString() }));
             }
         }
-        private static RedisKey ObjectToRedisKey(object obj)
+
+		/// <summary>
+		/// A Frends task for merging Json values in Redis.
+		/// Returns a Result-object with properties Success and Value.
+		/// </summary>
+		/// <param name="input">The command and parameters for the task</param>
+		/// <param name="connection">Connection-options</param>
+		/// <param name="options">Additional options for the task</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns>Object { bool Success, object Value }</returns>
+		public static Result Merge([PropertyTab] MergeInput input, [PropertyTab] Connection connection, [PropertyTab] Options options, CancellationToken cancellationToken)
+		{
+			ConnectionMultiplexer connectionMultiplexer = null;
+			setMinValue(options);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (connection.UseCachedConnection)
+			{
+				connectionMultiplexer = RedisConnectionFactory.Instance.GetCachedRedisConnectionFactory(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+			else
+			{
+				connectionMultiplexer = RedisConnectionFactory.CreateConnectionWithTimeout(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+
+			IDatabase database = connectionMultiplexer.GetDatabase();
+			
+			if (input.ObjectType == ObjectType.Json)
+			{
+				bool result;
+				if (input.JsonInput.Value is string)
+				{
+					var json = JsonConvert.DeserializeObject<dynamic>(input.JsonInput.Value.ToString());
+					result = database.JSON().Merge(ObjectToRedisKey(input.JsonInput.Key), string.IsNullOrEmpty(input.JsonInput.Path?.ToString()) ? "$" : input.JsonInput.Path.ToString(), JsonConvert.SerializeObject(json));
+				}
+				else
+				{
+					result = database.JSON().Merge(ObjectToRedisKey(input.JsonInput.Key), string.IsNullOrEmpty(input.JsonInput.Path?.ToString()) ? "$" : input.JsonInput.Path.ToString(), input.JsonInput.Value);
+				}
+
+				return new Result(result, null);
+			}
+			else
+			{
+				throw new ArgumentException("InputObjectType is of invalid type. Accepted types Json");
+			}
+		}
+
+		/// <summary>
+		/// A Frends task for executing RediSearch queries on Redis.
+		/// Returns a Result-object with properties Values.
+		/// </summary>
+		/// <param name="input">The command and parameters for the task</param>
+		/// <param name="connection">Connection-options</param>
+		/// <param name="options">Additional options for the task</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns> { object[] Values }</returns>
+		public static GetResult Query([PropertyTab] JsonQueryInput input, [PropertyTab] Connection connection, [PropertyTab] Options options, CancellationToken cancellationToken)
+		{
+			ConnectionMultiplexer connectionMultiplexer = null;
+			List<object> results = new List<object>();
+			setMinValue(options);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (connection.UseCachedConnection)
+			{
+				connectionMultiplexer = RedisConnectionFactory.Instance.GetCachedRedisConnectionFactory(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+			else
+			{
+				connectionMultiplexer = RedisConnectionFactory.CreateConnectionWithTimeout(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+
+			IDatabase database = connectionMultiplexer.GetDatabase();
+
+			SearchResult searchResult = database.FT().Search(
+				input.IndexName,
+				new(input.Query)
+			);
+
+			var documents = searchResult.Documents.Select(x => x["json"]);
+
+			foreach (RedisValue value in documents)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				results.Add(value);
+			}
+
+			return new GetResult(results);
+		}
+
+		/// <summary>
+		/// A Frends task for creating a RediSearch index on Redis. 
+		/// Returns a Result-object with properties Success and Value.
+		/// </summary>
+		/// <param name="input">The command and parameters for the task</param>
+		/// <param name="connection">Connection-options</param>
+		/// <param name="options">Additional options for the task</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns> { bool Success, object Value }</returns>
+		public static Result CreateIndex([PropertyTab] IndexCreateInput input, [PropertyTab] Connection connection, [PropertyTab] Options options, CancellationToken cancellationToken)
+		{
+			ConnectionMultiplexer connectionMultiplexer = null;
+			setMinValue(options);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (connection.UseCachedConnection)
+			{
+				connectionMultiplexer = RedisConnectionFactory.Instance.GetCachedRedisConnectionFactory(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+			else
+			{
+				connectionMultiplexer = RedisConnectionFactory.CreateConnectionWithTimeout(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+
+			IDatabase database = connectionMultiplexer.GetDatabase();
+			var schema = new Schema();
+
+			foreach (var field in input.Parameters)
+			{
+				if (field.FieldType == FieldDefinitionType.Text)
+				{
+					schema.AddTextField(new FieldName(field.Name, field.Attribute));
+				}
+				else if (field.FieldType == FieldDefinitionType.Tag)
+				{
+					schema.AddTagField(new FieldName(field.Name, field.Attribute));
+				}
+				else if (field.FieldType == FieldDefinitionType.Numeric)
+				{
+					schema.AddNumericField(new FieldName(field.Name, field.Attribute));
+				}
+			}
+
+			var indexCreated = database.FT()
+				.Create(
+					input.Name,
+					new FTCreateParams()
+						.On(IndexDataType.JSON)
+						.Prefix(input.Prefix),
+					schema);
+
+			return new Result(indexCreated, null);
+		}
+
+		/// <summary>
+		/// A Frends task for deleting a RediSearch index on Redis.
+		/// </summary>
+		/// <param name="input">The command and parameters for the task</param>
+		/// <param name="connection">Connection-options</param>
+		/// <param name="options">Additional options for the task</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns> { bool Success, object Value }</returns>
+		public static Result DeleteIndex([PropertyTab] IndexDeleteInput input, [PropertyTab] Connection connection, [PropertyTab] Options options, CancellationToken cancellationToken)
+		{
+			ConnectionMultiplexer connectionMultiplexer = null;
+			setMinValue(options);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (connection.UseCachedConnection)
+			{
+				connectionMultiplexer = RedisConnectionFactory.Instance.GetCachedRedisConnectionFactory(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+			else
+			{
+				connectionMultiplexer = RedisConnectionFactory.CreateConnectionWithTimeout(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+
+			IDatabase database = connectionMultiplexer.GetDatabase();
+			var indexDeleted = database.FT()
+				.DropIndex(
+					input.Name,
+					input.DeleteDocuments);
+
+			return new Result(indexDeleted, null);
+		}
+
+		/// <summary>
+		/// A Frends task for updating a RediSearch index on Redis.
+		/// </summary>
+		/// <param name="input">The command and parameters for the task</param>
+		/// <param name="connection">Connection-options</param>
+		/// <param name="options">Additional options for the task</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns> { bool Success, object Value }</returns>
+		public static Result UpdateIndex([PropertyTab] IndexUpdateInput input, [PropertyTab] Connection connection, [PropertyTab] Options options, CancellationToken cancellationToken)
+		{
+			ConnectionMultiplexer connectionMultiplexer = null;
+			setMinValue(options);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (connection.UseCachedConnection)
+			{
+				connectionMultiplexer = RedisConnectionFactory.Instance.GetCachedRedisConnectionFactory(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+			else
+			{
+				connectionMultiplexer = RedisConnectionFactory.CreateConnectionWithTimeout(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+
+			IDatabase database = connectionMultiplexer.GetDatabase();
+			var schema = new Schema();
+			var info = database.FT().Info(input.Name);
+
+			foreach (var field in input.Parameters)
+			{
+				bool fieldExist = info.Attributes.Any(a => a.ContainsKey("identifier") && a["identifier"].ToString() == field.Name);
+
+				if (!fieldExist)
+				{
+					if (field.FieldType == FieldDefinitionType.Text)
+					{
+						schema.AddTextField(new FieldName(field.Name, field.Attribute));
+					}
+					else if (field.FieldType == FieldDefinitionType.Tag)
+					{
+						schema.AddTagField(new FieldName(field.Name, field.Attribute));
+					}
+					else if (field.FieldType == FieldDefinitionType.Numeric)
+					{
+						schema.AddNumericField(new FieldName(field.Name, field.Attribute));
+					}
+				}
+			}
+
+			if (schema.Fields.Count == 0)
+			{
+				return new Result(true, "No new fields to add.");
+			}
+
+			var indexUpdated = database.FT()
+				.Alter(
+					input.Name,
+					schema);
+
+			return new Result(indexUpdated, null);
+		}
+
+		/// <summary>
+		/// A Frends task for creating or updating a RediSearch index on Redis.
+		/// If the index does not exist, it will be created. If it exists, it will be updated with new fields.
+		/// </summary>
+		/// <param name="input">The command and parameters for the task</param>
+		/// <param name="connection">Connection-options</param>
+		/// <param name="options">Additional options for the task</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns> { bool Success, object Value }</returns>
+		public static Result CreateOrUpdateIndex([PropertyTab] IndexCreateOrUpdateInput input, [PropertyTab] Connection connection, [PropertyTab] Options options, CancellationToken cancellationToken)
+		{
+			ConnectionMultiplexer connectionMultiplexer = null;
+			setMinValue(options);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (connection.UseCachedConnection)
+			{
+				connectionMultiplexer = RedisConnectionFactory.Instance.GetCachedRedisConnectionFactory(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+			else
+			{
+				connectionMultiplexer = RedisConnectionFactory.CreateConnectionWithTimeout(connection.ConnectionString, new TimeSpan(0, 0, connection.Timeout));
+			}
+
+			IDatabase database = connectionMultiplexer.GetDatabase();
+			var list = database.FT()._List();
+			bool exists = list.Any(i => i.ToString() == input.Name);
+
+			// Create index if it does not exist
+			if (!exists)
+			{
+				return CreateIndex(new IndexCreateInput
+				{
+					Name = input.Name,
+					Prefix = input.Prefix,
+					Parameters = input.Parameters
+				}, connection, options, cancellationToken);
+			}
+
+			// Update index if it exists
+			return UpdateIndex(new IndexUpdateInput
+			{
+				Name = input.Name,
+				Parameters = input.Parameters
+			}, connection, options, cancellationToken);
+		}
+
+
+		internal static RedisKey ObjectToRedisKey(object obj)
         {
             switch (obj)
             {
@@ -211,7 +545,8 @@ namespace Frends.Community.Redis
                     throw new ArgumentException("Key is a of invalid type. Accepted types are byte[] and string");
             }
         }
-        private static RedisValue ObjectToRedisValue(object obj)
+
+		internal static RedisValue ObjectToRedisValue(object obj)
         {
             switch (obj)
             {
@@ -227,7 +562,7 @@ namespace Frends.Community.Redis
                     return (RedisValue)booleanVal;
                 case string strVal:
                     return (RedisValue)strVal;
-                default:
+				default:
                     throw new ArgumentException("Could not convert key to correct format. Accepted types are int32, int64, byte[], double, boolean or string");
             }
         }

--- a/Frends.Community.Redis/Frends.Community.Redis.csproj
+++ b/Frends.Community.Redis/Frends.Community.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net471;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <authors>HiQ Finland</authors>
     <copyright>HiQ Finland</copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="NRedisStack" Version="1.3.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.12.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/Frends.Community.Redis/FrendsTaskMetadata.json
+++ b/Frends.Community.Redis/FrendsTaskMetadata.json
@@ -11,6 +11,24 @@
 		},
 		{
 			"TaskMethod": "Frends.Community.Redis.Redis.Command"
+		},
+		{
+			"TaskMethod": "Frends.Community.Redis.Redis.Merge"
+		},
+		{
+			"TaskMethod": "Frends.Community.Redis.Redis.Query"
+		},
+		{
+			"TaskMethod": "Frends.Community.Redis.Redis.CreateIndex"
+		},
+		{
+			"TaskMethod": "Frends.Community.Redis.Redis.DeleteIndex"
+		},
+		{
+			"TaskMethod": "Frends.Community.Redis.Redis.UpdateIndex"
+		},
+		{
+			"TaskMethod": "Frends.Community.Redis.Redis.CreateOrUpdateIndex"
 		}
 	]
 }

--- a/Frends.Community.Redis/InternalsVisibleTo.cs
+++ b/Frends.Community.Redis/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Frends.Community.Redis.Tests")]

--- a/README.md
+++ b/README.md
@@ -6,41 +6,50 @@ frends Community Task for Redis.
 
 - [Installing](#installing)
 - [Tasks](#tasks)
-     - [Add](#Add)
-       - [KeyValuePairInput](#KeyValuePairInput)
-       - [SetInput](#SetInput)
-     - [Get](#Get)
-     - [Remove](#Remove)
-     - [Command](#Command)
+     - [Add](#add)
+       - [KeyValuePairInput](#keyvaluepairinput)
+       - [SetInput](#setinput)
+       - [JsonInput](#jsoninput)
+     - [Get](#get)
+     - [Remove](#remove)
+     - [Command](#command)
+     - [Merge](#merge)
+     - [Query](#query)
+     - [CreateIndex](#createindex)
+     - [DeleteIndex](#deleteindex)
+     - [UpdateIndex](#updateindex)
+     - [CreateOrUpdateIndex](#createorupdateindex)
 - [Building](#building)
 - [Contributing](#contributing)
 - [Change Log](#change-log)
 
 # Installing
 
-You can install the Task via frends UI Task View or you can find the NuGet package from the following NuGet feed
-https://www.myget.org/F/frends-community/api/v3/index.json and in Gallery view in MyGet https://www.myget.org/feed/frends-community/package/nuget/Frends.Community.Redis
+You can install the Task via frends UI Task View or you can find the NuGet package from the following NuGet feed:
+- [NuGet Feed](https://www.myget.org/F/frends-community/api/v3/index.json)
+- [MyGet Gallery](https://www.myget.org/feed/frends-community/package/nuget/Frends.Community.Redis)
 
 # Tasks
 
 ## Add
 
-A task for adding and updating key-value pairs or Sets to Redis.
+A task for adding and updating key-value pairs, Sets, or JSON documents to Redis.
 
 ### Input
 
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
-| ObjectType | `Enum<KeyValuePair, Set>` | Choose the type how values are stored to Redis. | `KeyValuePair` |
+| ObjectType | `Enum<KeyValuePair, Set, Json>` | Choose the type how values are stored to Redis. | `KeyValuePair` |
 | KeyValuePairInput | Array of `KeyValuePairInput` | Pairs to be stored in Redis. | See below |
 | SetInput | Array of `SetInput` | Sets to be stored in Redis. | See below |
+| JsonInput | Array of `JsonInput` | JSON documents to be stored in Redis. | See below |
 
 #### KeyValuePairInput
 
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
 | Key | `object` | The chosen key for the key-value pair. | `myvalues` |
-| Value | `object` | An object containing the values to be stored. | `"[{\"id\":201,\"name\":\"SkiBussi 1 GPS\",\"direction\":-1,\"geolocation\":{\"lat\":67.8045555581415,\"lon\":24.8096944500295},\"route\":2}]"` |
+| Value | `object` | An object containing the values to be stored. | `"[{\"id\":201,\"name\":\"SkiBussi 1 GPS\"}]"` |
 | TimeToLive | `TimeSpan` | TimeToLive limit for the value. |  |
 | ValueExists | `Enum<InsertAlways, InsertOnlyIfValueExists, InsertOnlyIfValueDoesNotExist>` | What to do when value exists. | `InsertAlways` |
 
@@ -49,7 +58,15 @@ A task for adding and updating key-value pairs or Sets to Redis.
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
 | Key | `object` | The chosen key for the set of values. | `myvalues` |
-| Value | Array of `object` | An array of values to be stored. | `"[{\"id\":201,\"name\":\"SkiBussi 1 GPS\",\"direction\":-1,\"geolocation\":{\"lat\":67.8045555581415,\"lon\":24.8096944500295},\"route\":2}]"` |
+| Value | Array of `object` | An array of values to be stored. | `["value1", "value2"]` |
+
+#### JsonInput
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Key | `object` | The chosen key for the JSON document. | `user:1` |
+| Value | `object` | The JSON value to be stored. Can be a JSON string or object. | `"{\"name\":\"John\",\"age\":30}"` |
+| Path | `object` | JSONPath to specify where to store the value. Defaults to root `$`. Nonexistent paths are ignored. | `$.address` |
 
 ### Connection
 
@@ -68,7 +85,7 @@ A task for adding and updating key-value pairs or Sets to Redis.
 
 ### Returns
 
-For each key-value pair or set, the task returns a list of result objects with following properties:
+For each key-value pair, set, or JSON document, the task returns a list of result objects with the following properties:
 
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
@@ -84,21 +101,22 @@ A task for getting stored data from Redis.
 
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
-| ObjectType | `Enum<KeyValuePair, Set>` | Choose the type how values are stored in Redis. | `KeyValuePair` |
+| ObjectType | `Enum<KeyValuePair, Set, Json>` | Choose the type how values are stored in Redis. | `KeyValuePair` |
 | Key | `object[]` | Array of keys for key-value pairs to fetch. | `["myvalue"]` |
 | SetKey | `object` | The key for the set to fetch. | `"myvalue"` |
+| JsonKey | `object` | The key for the JSON document to fetch. | `"user:1"` |
 
 ### Connection
 
-For connections settings, see [Connection](#Connection)
+For connections settings, see [Connection](#connection)
 
 ### Options
 
-For other settings, see [Options](#Options)
+For other settings, see [Options](#options)
 
 ### Returns
 
-Task returns an object with following properties
+Task returns an object with the following properties:
 
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
@@ -107,27 +125,28 @@ Task returns an object with following properties
 
 ## Remove
 
-A task for removing wanted data from Redis.
+A task for removing unwanted data from Redis.
 
 ### Input
 
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
-| ObjectType | `Enum<KeyValuePair, Set>` | Choose the type how values are stored in Redis. | `KeyValuePair` |
-| Key | `object[]` | Array of keys for key-value pairs to fetch. | `["myvalue"]` |
-| SetInput | `SetInput` | Set values to be removed. For more info, see [SetInput](#SetInput). | `""` |
+| ObjectType | `Enum<KeyValuePair, Set, Json>` | Choose the type how values are stored in Redis. | `KeyValuePair` |
+| Key | `object[]` | Array of keys for key-value pairs to delete. | `["myvalue"]` |
+| SetInput | `SetInput` | Set values to be removed. For more info, see [SetInput](#setinput). | |
+| JsonInput | `JsonInput` | JSON document or path to be removed. For more info, see [JsonInput](#jsoninput). | |
 
 ### Connection
 
-For connections settings, see [Connection](#Connection)
+For connections settings, see [Connection](#connection)
 
 ### Options
 
-For other settings, see [Options](#Options)
+For other settings, see [Options](#options)
 
 ### Returns
 
-For each key-value pair or set, the task returns a list of result objects with following properties:
+The task returns a result object with the following properties:
 
 | Property | Type | Description | Example |
 | -------- | -------- | -------- | -------- |
@@ -148,35 +167,219 @@ A task for executing commands on Redis.
 
 ### Connection
 
-For connections settings, see [Connection](#Connection)
+For connections settings, see [Connection](#connection)
 
 ### Options
 
-For other settings, see [Options](#Options)
+For other settings, see [Options](#options)
 
 ### Returns
 
 Task returns `IEnumerable<string>` that contains the results of the command.
 
+## Merge
+
+A task for merging JSON values in Redis using the JSON.MERGE command.
+
+### Input
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| ObjectType | `Enum<Json>` | The type of object. Currently only `Json` is supported. | `Json` |
+| JsonInput | `JsonInput` | The JSON document to merge. For more info, see [JsonInput](#jsoninput). | |
+
+### Connection
+
+For connections settings, see [Connection](#connection)
+
+### Options
+
+For other settings, see [Options](#options)
+
+### Returns
+
+Task returns a result object with the following properties:
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Success | `bool` | Tells whether or not the merge succeeded. | `true` |
+| Value | `object` | Always `null` for this task. | |
+| ToJToken() | `JToken` | Returns the value of `Value` as JToken. | |
+
+## Query
+
+A task for executing RediSearch queries on Redis (requires RedisSearch module).
+
+### Input
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| IndexName | `string` | The name of the RediSearch index to query. | `idx:users` |
+| Query | `string` | The RediSearch query string. | `Paul @age:[30 40]` |
+
+### Connection
+
+For connections settings, see [Connection](#connection)
+
+### Options
+
+For other settings, see [Options](#options)
+
+### Returns
+
+Task returns an object with the following properties:
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Values | `List<object>` | List of matching JSON documents. | |
+| ToJToken() | `JToken` | Returns the value of `Values` as JToken. | |
+
+## CreateIndex
+
+A task for creating a RediSearch index on Redis (requires RedisSearch module). The index is created on JSON documents with the specified prefix.
+
+### Input
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Name | `string` | The name of the index to create. | `idx:users` |
+| Prefix | `string` | The key prefix for documents to be indexed. | `user:` |
+| Parameters | Array of `IndexFieldDefinition` | The fields to include in the index. | See below |
+
+#### IndexFieldDefinition
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| FieldType | `Enum<Text, Geo, GeoShape, Numeric, Tag, Vector>` | The type of the field. | `Text` |
+| Name | `string` | The JSONPath expression for the field identifier. | `$.name` |
+| Attribute | `string` | An alias for the JSONPath expression. | `name` |
+
+### Connection
+
+For connections settings, see [Connection](#connection)
+
+### Options
+
+For other settings, see [Options](#options)
+
+### Returns
+
+Task returns a result object with the following properties:
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Success | `bool` | Tells whether or not the index was created. | `true` |
+| Value | `object` | Always `null` for this task. | |
+| ToJToken() | `JToken` | Returns the value of `Value` as JToken. | |
+
+## DeleteIndex
+
+A task for deleting a RediSearch index on Redis (requires RedisSearch module).
+
+### Input
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Name | `string` | The name of the index to delete. | `idx:users` |
+| DeleteDocuments | `bool` | Whether to also delete the documents associated with the index. | `false` |
+
+### Connection
+
+For connections settings, see [Connection](#connection)
+
+### Options
+
+For other settings, see [Options](#options)
+
+### Returns
+
+Task returns a result object with the following properties:
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Success | `bool` | Tells whether or not the index was deleted. | `true` |
+| Value | `object` | Always `null` for this task. | |
+| ToJToken() | `JToken` | Returns the value of `Value` as JToken. | |
+
+## UpdateIndex
+
+A task for updating an existing RediSearch index by adding new fields (requires RedisSearch module). Only fields that do not already exist in the index are added.
+
+### Input
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Name | `string` | The name of the index to update. | `idx:users` |
+| Parameters | Array of `IndexFieldDefinition` | The fields to add to the index. Fields already present are skipped. | See [IndexFieldDefinition](#indexfielddefinition) |
+
+### Connection
+
+For connections settings, see [Connection](#connection)
+
+### Options
+
+For other settings, see [Options](#options)
+
+### Returns
+
+Task returns a result object with the following properties:
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Success | `bool` | Tells whether or not the index was updated. | `true` |
+| Value | `object` | `"No new fields to add."` if no changes were needed, otherwise `null`. | |
+| ToJToken() | `JToken` | Returns the value of `Value` as JToken. | |
+
+## CreateOrUpdateIndex
+
+A task for creating or updating a RediSearch index on Redis (requires RedisSearch module). If the index does not exist it will be created; if it already exists, only new fields will be added.
+
+### Input
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Name | `string` | The name of the index to create or update. | `idx:users` |
+| Prefix | `string` | The key prefix for documents to be indexed. Used only when creating a new index. | `user:` |
+| Parameters | Array of `IndexFieldDefinition` | The fields to include in or add to the index. | See [IndexFieldDefinition](#indexfielddefinition) |
+
+### Connection
+
+For connections settings, see [Connection](#connection)
+
+### Options
+
+For other settings, see [Options](#options)
+
+### Returns
+
+Task returns a result object with the following properties:
+
+| Property | Type | Description | Example |
+| -------- | -------- | -------- | -------- |
+| Success | `bool` | Tells whether or not the operation succeeded. | `true` |
+| Value | `object` | `"No new fields to add."` if no changes were needed, otherwise `null`. | |
+| ToJToken() | `JToken` | Returns the value of `Value` as JToken. | |
+
 # Building
 
-Clone a copy of the repository
+Clone a copy of the repository:
 
-`git clone https://github.com/CommunityHiQ/Frends.Community.Redis.git`
+git clone https://github.com/CommunityHiQ/Frends.Community.Redis.git
 
-Rebuild the project
+Rebuild the project:
 
-`dotnet build`
+dotnet build
 
-Run tests
+Run tests:
 
-`dotnet test`
+dotnet test
 
-Create a NuGet package
+Create a NuGet package:
 
-`dotnet pack --configuration Release`
+dotnet pack --configuration Release
 
 # Contributing
+
 When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
 
 1. Fork the repository on GitHub
@@ -185,7 +388,7 @@ When contributing to this repository, please first discuss the change you wish t
 4. Push your work back up to your fork
 5. Submit a Pull request so that we can review your changes
 
-NOTE: Be sure to merge the latest from "upstream" before making a pull request!
+**NOTE:** Be sure to merge the latest from "upstream" before making a pull request!
 
 # Change Log
 
@@ -195,4 +398,5 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 1.0.2   | Renamed the property for IOCs. |
 | 1.0.3   | ToJToken() added to result objects. |
 | 1.0.4   | Downgraded Newtonsoft.Json to 12.0.0.0 |
-| 1.1.0   | Added targeting to .NET6 and .NET8. Updated StackExchange.Redis to 2.8.24 and downgraded Newtonsoft.Json to 12.0.1.|
+| 1.1.0   | Added targeting to .NET6 and .NET8. Updated StackExchange.Redis to 2.8.24 and downgraded Newtonsoft.Json to 12.0.1. |
+| 2.0.0   | **Breaking:** Dropped .NET 6 support, targeting .NET 8 only. Updated Newtonsoft.Json to 13.0.4, NRedisStack to 1.3.0, and StackExchange.Redis to 2.12.4. Added JSON support (RedisJSON) to Add, Get, and Remove tasks. Added new tasks: Merge, Query, CreateIndex, DeleteIndex, UpdateIndex, and CreateOrUpdateIndex (requires RedisSearch module). |


### PR DESCRIPTION
Breaking: Now targets .NET 8 only. Added support for RedisJSON (add/get/remove/merge JSON) and RediSearch (query, create/delete/update indexes). Introduced new tasks: Merge, Query, CreateIndex, DeleteIndex, UpdateIndex, CreateOrUpdateIndex. Updated dependencies (Newtonsoft.Json 13.0.4, StackExchange.Redis 2.12.4, NRedisStack 1.3.0). Extended input/output types for JSON and index operations. Switched tests to MSTest, added comprehensive coverage for new features. Updated documentation and metadata for all changes. Internal APIs exposed to tests.